### PR TITLE
Adding termination callback for arbitrary termination.

### DIFF
--- a/pyade/de.py
+++ b/pyade/de.py
@@ -13,7 +13,8 @@ def get_default_params(dim: int) -> dict:
     :rtype dict
     """
     return {'callback': None, 'max_evals': 10000 * dim, 'seed': None, 'cross': 'bin',
-            'f': 0.5, 'cr': 0.9, 'individual_size': dim, 'population_size': 10 * dim, 'opts': None}
+            'f': 0.5, 'cr': 0.9, 'individual_size': dim, 'population_size': 10 * dim, 'opts': None,
+            'terminate_callback': None}
 
 
 def apply(population_size: int, individual_size: int, f: Union[float, int],
@@ -21,7 +22,8 @@ def apply(population_size: int, individual_size: int, f: Union[float, int],
           func: Callable[[np.ndarray], float], opts: Any,
           callback: Callable[[Dict], Any],
           cross: str,
-          max_evals: int, seed: Union[int, None]) -> [np.ndarray, int]:
+          max_evals: int, seed: Union[int, None],
+          terminate_callback: Callable[[], bool]) -> [np.ndarray, int]:
     """
     Applies the standard differential evolution algorithm.
     :param population_size: Size of the population.
@@ -50,6 +52,8 @@ def apply(population_size: int, individual_size: int, f: Union[float, int],
     :param seed: Random number generation seed. Fix a number to reproduce the
     same results in later experiments.
     :type seed: Union[int, None]
+    :param terminate_callback: Callback that checks whether it is time to terminate or not. The callback should return True if it's time to stop, otherwise False.
+    :type terminate_callback: Callable[[], bool]
     :return: A pair with the best solution found and its fitness.
     :rtype [np.ndarray, int]
     """
@@ -89,6 +93,9 @@ def apply(population_size: int, individual_size: int, f: Union[float, int],
 
     max_iters = max_evals // population_size
     for current_generation in range(max_iters):
+        if terminate_callback is not None and terminate_callback():
+            break
+
         mutated = pyade.commons.binary_mutation(population, f, bounds)
         if cross == 'bin':
             crossed = pyade.commons.crossover(population, mutated, cr)

--- a/pyade/ilshade.py
+++ b/pyade/ilshade.py
@@ -15,13 +15,15 @@ def get_default_params(dim: int):
         :rtype dict
     """
     return {'population_size': 12 * dim, 'individual_size': dim, 'memory_size': 6,
-            'max_evals': 10000 * dim, 'callback': None, 'seed': None, 'opts': None}
+            'max_evals': 10000 * dim, 'callback': None, 'seed': None, 'opts': None,
+            'terminate_callback': None}
 
 
 def apply(population_size: int, individual_size: int, bounds: np.ndarray,
           func: Callable[[np.ndarray], float], opts: Any,
           memory_size: int, callback: Callable[[Dict], Any],
-          max_evals: int, seed: Union[int, None]) -> [np.ndarray, int]:
+          max_evals: int, seed: Union[int, None],
+          terminate_callback: Callable[[], bool]) -> [np.ndarray, int]:
     """
     Applies the iL-SHADE differential evolution algorithm.
     :param population_size: Size of the population.
@@ -46,6 +48,8 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
     :param seed: Random number generation seed. Fix a number to reproduce the
     same results in later experiments.
     :type seed: Union[int, None]
+    :param terminate_callback: Callback that checks whether it is time to terminate or not. The callback should return True if it's time to stop, otherwise False.
+    :type terminate_callback: Callable[[], bool]
     :return: A pair with the best solution found and its fitness.
     :rtype [np.ndarray, int]
     """
@@ -96,7 +100,7 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
         n = round((4 - population_size) / max_evals * i + population_size)
         i += n
 
-    while num_evals < max_evals:
+    while num_evals < max_evals and (terminate_callback is not None and not terminate_callback()):
         # 2.1 Adaptation
         r = np.random.choice(memory_indexes, current_size)
         m_cr[- 1] = 0.9

--- a/pyade/jade.py
+++ b/pyade/jade.py
@@ -14,13 +14,15 @@ def get_default_params(dim: int) -> dict:
         """
     pop_size = 10 * dim
     return {'max_evals': 10000 * dim, 'individual_size': dim, 'callback': None,
-            'population_size': pop_size, 'c': 0.1, 'p': max(.05, 3/pop_size), 'seed': None}
+            'population_size': pop_size, 'c': 0.1, 'p': max(.05, 3/pop_size), 'seed': None,
+            'opts': None, 'terminate_callback': None}
 
 
 def apply(population_size: int, individual_size: int, bounds: np.ndarray,
           func: Callable[[np.ndarray], float], opts: Any,
           p: Union[int, float], c: Union[int, float], callback: Callable[[Dict], Any],
-          max_evals: int, seed: Union[int, None]) -> [np.ndarray, int]:
+          max_evals: int, seed: Union[int, None],
+          terminate_callback: Callable[[], bool]) -> [np.ndarray, int]:
     """
     Applies the JADE Differential Evolution algorithm.
     :param population_size: Size of the population.
@@ -47,6 +49,8 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
     :param seed: Random number generation seed. Fix a number to reproduce the
     same results in later experiments.
     :type seed: Union[int, None]
+    :param terminate_callback: Callback that checks whether it is time to terminate or not. The callback should return True if it's time to stop, otherwise False.
+    :type terminate_callback: Callable[[], bool]
     :return: A pair with the best solution found and its fitness.
     :rtype [np.ndarray, int]
     """
@@ -84,6 +88,8 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
     fitness = pyade.commons.apply_fitness(population, func, opts)
     max_iters = max_evals // population_size
     for current_generation in range(max_iters):
+        if terminate_callback is not None and terminate_callback():
+            break
         # 2.1 Generate parameter values for current generation
         cr = np.random.normal(u_cr, 0.1, population_size)
         f = np.random.rand(population_size // 3) * 1.2

--- a/pyade/jso.py
+++ b/pyade/jso.py
@@ -15,13 +15,15 @@ def get_default_params(dim: int):
     """
     return {'population_size': int(round(25 * np.log(dim) * np.sqrt(dim))),
             'individual_size': dim, 'memory_size': 5,
-            'max_evals': 10000 * dim, 'seed': None, 'callback': None, 'opts': None}
+            'max_evals': 10000 * dim, 'seed': None, 'callback': None, 'opts': None,
+            'terminate_callback': None}
 
 
 def apply(population_size: int, individual_size: int, bounds: np.ndarray,
           func: Callable[[np.ndarray], float], opts: Any,
           memory_size: int, callback: Callable[[Dict], Any],
-          max_evals: int, seed: Union[int, None]) -> [np.ndarray, int]:
+          max_evals: int, seed: Union[int, None],
+          terminate_callback: Callable[[], bool]) -> [np.ndarray, int]:
     """
     Applies the jSO differential evolution algorithm.
     :param population_size: Size of the population.
@@ -46,6 +48,8 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
     :param seed: Random number generation seed. Fix a number to reproduce the
     same results in later experiments.
     :type seed: Union[int, None]
+    :param terminate_callback: Callback that checks whether it is time to terminate or not. The callback should return True if it's time to stop, otherwise False.
+    :type terminate_callback: Callable[[], bool]
     :return: A pair with the best solution found and its fitness.
     :rtype [np.ndarray, int]
     """
@@ -96,7 +100,7 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
         n = round((4 - population_size) / max_evals * i + population_size)
         i += n
 
-    while num_evals < max_evals:
+    while num_evals < max_evals and (terminate_callback is not None and not terminate_callback()):
         # 2.1 Adaptation
         r = np.random.choice(memory_indexes, current_size)
         m_cr[- 1] = 0.9

--- a/pyade/lshade.py
+++ b/pyade/lshade.py
@@ -15,13 +15,15 @@ def get_default_params(dim: int):
         :rtype dict
     """
     return {'max_evals': 10000 * dim, 'population_size': 18 * dim, 'individual_size': dim,
-            'memory_size': 6, 'callback': None, 'seed': None, 'opts': None}
+            'memory_size': 6, 'callback': None, 'seed': None, 'opts': None,
+            'terminate_callback': None}
 
 
 def apply(population_size: int, individual_size: int, bounds: np.ndarray,
           func: Callable[[np.ndarray], np.float], opts: Any,
           memory_size: int, callback: Callable[[Dict], Any],
-          max_evals: int, seed: Union[int, None]) -> [np.ndarray, int]:
+          max_evals: int, seed: Union[int, None],
+          terminate_callback: Callable[[], bool]) -> [np.ndarray, int]:
     """
     Applies the L-SHADE Differential Evolution Algorithm.
     :param population_size: Size of the population.
@@ -46,6 +48,8 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
     :param seed: Random number generation seed. Fix a number to reproduce the
     same results in later experiments.
     :type seed: Union[int, None]
+    :param terminate_callback: Callback that checks whether it is time to terminate or not. The callback should return True if it's time to stop, otherwise False.
+    :type terminate_callback: Callable[[], bool]
     :return: A pair with the best solution found and its fitness.
     :rtype [np.ndarray, int]
     """
@@ -96,7 +100,7 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
         n = round((4 - init_size) / max_evals * i + init_size)
         i += n
 
-    while num_evals < max_evals:
+    while num_evals < max_evals and (terminate_callback is not None and not terminate_callback()):
         # 2.1 Adaptation
         r = np.random.choice(all_indexes, population_size)
         cr = np.random.normal(m_cr[r], 0.1, population_size)

--- a/pyade/lshadecnepsin.py
+++ b/pyade/lshadecnepsin.py
@@ -18,14 +18,16 @@ def get_default_params(dim: int):
     return {'population_size': 18 * dim,
             'min_population_size': 4,
             'individual_size': dim, 'memory_size': 5,
-            'max_evals': 10000 * dim, 'seed': None, 'callback': None, 'opts': None}
+            'max_evals': 10000 * dim, 'seed': None, 'callback': None, 'opts': None,
+            'terminate_callback': None}
 
 
 def apply(population_size: int, individual_size: int, bounds: np.ndarray,
           func: Callable[[np.ndarray], float], opts: Any,
           memory_size: int, callback: Callable[[Dict], Any],
           min_population_size: int,
-          max_evals: int, seed: Union[int, None]) -> [np.ndarray, int]:
+          max_evals: int, seed: Union[int, None],
+          terminate_callback: Callable[[], bool]) -> [np.ndarray, int]:
     """
     Applies the L-SHADE-cnEpSin differential evolution algorithm.
     :param population_size: Size of the population (NP-max)
@@ -51,6 +53,8 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
     :param seed: Random number generation seed. Fix a number to reproduce the
     same results in later experiments.
     :type seed: Union[int, None]
+    :param terminate_callback: Callback that checks whether it is time to terminate or not. The callback should return True if it's time to stop, otherwise False.
+    :type terminate_callback: Callable[[], bool]
     :return: A pair with the best solution found and its fitness.
     :rtype [np.ndarray, int]
     """
@@ -111,7 +115,7 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
         i += n
 
     current_generation = 0
-    while num_evals < max_evals:
+    while num_evals < max_evals and (terminate_callback is not None and not terminate_callback()):
         # Mutation
         if current_generation <= (max_iters / 2):
             if current_generation <= lp:

--- a/pyade/mpede.py
+++ b/pyade/mpede.py
@@ -16,8 +16,8 @@ def get_default_params(dim: int) -> dict:
     pop_size = 250
     return {'max_evals': 10000 * dim, 'individual_size': dim, 'callback': None,
             'population_size': pop_size, 'seed': None, 'lambdas': [0.2, 0.2, 0.2, 0.4],
-            'ng': 20, 'c': 0.1, 'p': 0.04, 'opts': None
-            }
+            'ng': 20, 'c': 0.1, 'p': 0.04, 'opts': None,
+            'terminate_callback': None}
 
 
 def apply(population_size: int, individual_size: int, bounds: np.ndarray,
@@ -25,7 +25,8 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
           callback: Callable[[Dict], Any],
           lambdas: Union[list, np.array],
           ng: int, c: Union[int, float], p: Union[int, float],
-          max_evals: int, seed: Union[int, None]) -> [np.ndarray, int]:
+          max_evals: int, seed: Union[int, None],
+          terminate_callback: Callable[[], bool]) -> [np.ndarray, int]:
 
     """
     Applies the MPEDE differential evolution algorithm.
@@ -57,6 +58,8 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
     :param c: Variable to control parameter adoption. Must be in [0, 1].
     :type c: Union[int, float]
     :type seed: Union[int, None]
+    :param terminate_callback: Callback that checks whether it is time to terminate or not. The callback should return True if it's time to stop, otherwise False.
+    :type terminate_callback: Callable[[], bool]
     :return: A pair with the best solution found and its fitness.
     :rtype [np.ndarray, int]
 
@@ -123,7 +126,7 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
         num_evals += len(pops[j])
 
     # 2. Start the algorithm
-    while num_evals <= max_evals:
+    while num_evals < max_evals and (terminate_callback is not None and not terminate_callback()):
         current_generation += 1
 
         # 2.1 Generate CR and F values

--- a/pyade/sade.py
+++ b/pyade/sade.py
@@ -12,14 +12,16 @@ def get_default_params(dim: int) -> dict:
     :rtype dict
     """
     return {'max_evals': 10000 * dim, 'population_size': 10 * dim, 'callback': None,
-            'individual_size': dim, 'seed': None, 'opts': None}
+            'individual_size': dim, 'seed': None, 'opts': None,
+            'terminate_callback': None}
 
 
 def apply(population_size: int, individual_size: int,
           bounds: np.ndarray,
           func: Callable[[np.ndarray], float], opts: Any,
           callback: Callable[[Dict], Any],
-          max_evals: int, seed: Union[int, None]):
+          max_evals: int, seed: Union[int, None],
+          terminate_callback: Callable[[], bool]) -> [np.ndarray, int]:
     """
     Applies the Self-adaptive differential evolution algorithm (SaDE).
     :param population_size: Size of the population.
@@ -42,6 +44,8 @@ def apply(population_size: int, individual_size: int,
     :param seed: Random number generation seed. Fix a number to reproduce the
     same results in later experiments.
     :type seed: Union[int, None]
+    :param terminate_callback: Callback that checks whether it is time to terminate or not. The callback should return True if it's time to stop, otherwise False.
+    :type terminate_callback: Callable[[], bool]
     :return: A pair with the best solution found and its fitness.
     :rtype [np.ndarray, int]
     """
@@ -87,6 +91,8 @@ def apply(population_size: int, individual_size: int,
 
     max_iters = max_evals // population_size
     for current_generation in range(max_iters):
+        if terminate_callback is not None and terminate_callback():
+            break
         # 2.1 Mutation
         # 2.1.1 Randomly choose which individuals do each mutation
         choice = np.random.rand(population_size)

--- a/pyade/saepsdemmts.py
+++ b/pyade/saepsdemmts.py
@@ -31,14 +31,16 @@ def get_default_params(dim: int) -> dict:
     :rtype dict
     """
     return {'max_evals': 10000 * dim, 'population_size': 60, 'callback': None,
-            'individual_size': dim, 'seed': None, 'opts': None}
+            'individual_size': dim, 'seed': None, 'opts': None,
+            'terminate_callback': None}
 
 
 def apply(population_size: int, individual_size: int,
           bounds: np.ndarray,
           func: Callable[[np.ndarray], float], opts: Any,
           callback: Callable[[Dict], Any],
-          max_evals: int, seed: Union[int, None]):
+          max_evals: int, seed: Union[int, None],
+          terminate_callback: Callable[[], bool]) -> [np.ndarray, int]:
     """
     Applies the Self-adaptive differential evolution algorithm (SaDE).
     :param population_size: Size of the population.
@@ -88,7 +90,7 @@ def apply(population_size: int, individual_size: int,
     mmts_desired_evals = 60
     num_no_mmts = 0
 
-    while num_evals < max_evals:
+    while num_evals < max_evals and (terminate_callback is not None and not terminate_callback()):
 
         # 1. Generate ensemble parameters
         if current_generation == 1 or current_generation > learning_period:

--- a/pyade/shade.py
+++ b/pyade/shade.py
@@ -16,13 +16,15 @@ def get_default_params(dim: int):
     """
     return {'max_evals': 10000 * dim, 'memory_size': 100,
             'individual_size': dim, 'population_size': 10 * dim,
-            'callback': None, 'seed': None, 'opts': None}
+            'callback': None, 'seed': None, 'opts': None,
+            'terminate_callback': None}
 
 
 def apply(population_size: int, individual_size: int, bounds: np.ndarray,
           func: Callable[[np.ndarray], float], opts: Any,
           memory_size: int, callback: Callable[[Dict], Any],
-          max_evals: int, seed: Union[int, None]) -> [np.ndarray, int]:
+          max_evals: int, seed: Union[int, None],
+          terminate_callback: Callable[[], bool]) -> [np.ndarray, int]:
     """
     Applies the SHADE differential evolution algorithm.
     :param population_size: Size of the population.
@@ -47,6 +49,8 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
     :param seed: Random number generation seed. Fix a number to reproduce the
     same results in later experiments.
     :type seed: Union[int, None]
+    :param terminate_callback: Callback that checks whether it is time to terminate or not. The callback should return True if it's time to stop, otherwise False.
+    :type terminate_callback: Callable[[], bool]
     :return: A pair with the best solution found and its fitness.
     :rtype [np.ndarray, int]
     """
@@ -82,6 +86,8 @@ def apply(population_size: int, individual_size: int, bounds: np.ndarray,
     all_indexes = list(range(memory_size))
     max_iters = max_evals // population_size
     for current_generation in range(max_iters):
+        if terminate_callback is not None and terminate_callback():
+            break
         # 2.1 Adaptation
         r = np.random.choice(all_indexes, population_size)
         cr = np.random.normal(m_cr[r], 0.1, population_size)


### PR DESCRIPTION
pyade optimizers currently run until the execution or iteration budget is exhausted. I added a termination callback that can be used to stop execution based on other criteria such as CPU time, SIGINT, etc. Note that it is stateless, in that it does not receive any information from the function caller. That might be something to change in the future, but I justify this in that there already is a callback method providing all of the locals after each iteration for all of the optimizers. So one could just save information from the callback and decide whether or not to set a termination flag.